### PR TITLE
Use filter for multi-format templates

### DIFF
--- a/templates/Imprint_Address_of_Organization.html.twig
+++ b/templates/Imprint_Address_of_Organization.html.twig
@@ -1,3 +1,0 @@
-Wikimedia Deutschland e. V.{$ ( output == 'html' ? '<br />' ) $}
-Tempelhofer Ufer 23-24{$ ( output == 'html' ? '<br />' ) $}
-10963 Berlin{$ ( output == 'html' ? '<br />' ) $}

--- a/templates/Imprint_Address_of_Organization.txt.twig
+++ b/templates/Imprint_Address_of_Organization.txt.twig
@@ -1,0 +1,3 @@
+Wikimedia Deutschland e. V.
+Tempelhofer Ufer 23-24
+10963 Berlin

--- a/templates/Imprint_Address_of_Suborganization.html.twig
+++ b/templates/Imprint_Address_of_Suborganization.html.twig
@@ -1,3 +1,0 @@
-Gemeinnützige Wikimedia Fördergesellschaft mbH{$ ( output == 'html' ? '<br />' ) $}
-Tempelhofer Ufer 23-24{$ ( output == 'html' ? '<br />' ) $}
-10963 Berlin{$ ( output == 'html' ? '<br />' ) $}

--- a/templates/Imprint_Address_of_Suborganization.txt.twig
+++ b/templates/Imprint_Address_of_Suborganization.txt.twig
@@ -1,0 +1,3 @@
+Gemeinnützige Wikimedia Fördergesellschaft mbH
+Tempelhofer Ufer 23-24
+10963 Berlin

--- a/templates/Imprint_Content.html.twig
+++ b/templates/Imprint_Content.html.twig
@@ -4,13 +4,17 @@
 	</p>
 	<p>
 		<strong>Diensteanbieter</strong><br />
-		{% include 'Imprint_Address_of_Suborganization.html.twig' with { output: 'html' } %}
+		{% filter nl2br %}
+			{%- include 'Imprint_Address_of_Suborganization.txt.twig' %}
+		{% endfilter %}
+		<br />
 		E-Mail: spenden@wikimedia.de <br/>
 		Telefon: +49 (0)30-219 15 826-0 <br/>
 		Fax: +49 (0)180-522 71 17-619 (aus dem Festnetz: 14 ct/min, Mobilfunk max.: 42 ct/min) <br/>
 	</p>
 
 	<p>
+
 		<strong>{% include 'Imprint_Title_Head_of_Suborganization.html.twig' %}</strong><br />
 		{% include 'Imprint_Name_Head_of_Suborganization.html.twig' %}<br/>
 	</p>

--- a/templates/Mail_Contact_Confirm_to_User.txt.twig
+++ b/templates/Mail_Contact_Confirm_to_User.txt.twig
@@ -8,9 +8,7 @@ Mit freundlichen Grüßen
 Till Mletzko
 Teamleiter Fundraising
 -------------------------------------
-Gemeinnützige Wikimedia Fördergesellschaft mbH.
-Tempelhofer Ufer 23-24
-10963 Berlin
+{% include 'Imprint_Address_of_Suborganization.txt.twig' %}
 
 Telefon 030 - 219 158 26-19
 www.wikimedia.de

--- a/templates/Mail_Donation_Cancellation_Confirmation.txt.twig
+++ b/templates/Mail_Donation_Cancellation_Confirmation.txt.twig
@@ -13,7 +13,7 @@ Wissens frei teilhaben kann. Helfen Sie uns dabei!
 https://spenden.wikimedia.de/
 ---------------------------------------------------------------------------
 
-{% include 'Imprint_Address_of_Suborganization.html.twig' %}
+{% include 'Imprint_Address_of_Suborganization.txt.twig' %}
 
 Eingetragen beim Amtsgericht Berlin-Charlottenburg unter der Nummer HRB
 130183 B. Die Wikimedia Fördergesellschaft ist durch die Bescheinigung

--- a/templates/Mail_Donation_Confirmation.txt.twig
+++ b/templates/Mail_Donation_Confirmation.txt.twig
@@ -75,7 +75,7 @@ Wissens frei teilhaben kann. Helfen Sie uns dabei!
 https://spenden.wikimedia.de/
 ---------------------------------------------------------------------------
 
-{% include 'Imprint_Address_of_Suborganization.html.twig' %}
+{% include 'Imprint_Address_of_Suborganization.txt.twig' %}
 
 Eingetragen beim Amtsgericht Berlin-Charlottenburg unter der Nummer HRB
 130183 B. Die Wikimedia Fördergesellschaft ist durch die Bescheinigung

--- a/templates/Mail_Membership_Application_Cancellation_Confirmation.txt.twig
+++ b/templates/Mail_Membership_Application_Cancellation_Confirmation.txt.twig
@@ -9,7 +9,7 @@ Mit freundlichen Grüßen
 -------------------------------------
 Stellen Sie sich eine Welt vor, in der jeder Mensch an der Menge allen Wissens frei teilhaben kann. Helfen Sie uns dabei! https://spenden.wikimedia.de/
 
-{% include 'Imprint_Address_of_Organization.html.twig' %}
+{% include 'Imprint_Address_of_Organization.txt.twig' %}
 
 Telefon 030 - 219 158 26-19
 www.wikimedia.de

--- a/templates/Mail_Membership_Application_Confirmation.txt.twig
+++ b/templates/Mail_Membership_Application_Confirmation.txt.twig
@@ -33,7 +33,7 @@ Mit freundlichen Grüßen
 -------------------------------------
 Stellen Sie sich eine Welt vor, in der jeder Mensch an der Menge allen Wissens frei teilhaben kann. Helfen Sie uns dabei! https://www.wikimedia.de/
 
-{% include 'Imprint_Address_of_Organization.html.twig' %}
+{% include 'Imprint_Address_of_Organization.txt.twig' %}
 
 Telefon 030 - 219 158 26-19
 www.wikimedia.de

--- a/templates/Mail_Subscription_Confirmation.txt.twig
+++ b/templates/Mail_Subscription_Confirmation.txt.twig
@@ -12,7 +12,7 @@ P.S. Eine Online-Spende können Sie auf unserer Spendenseite zu jeder Zeit absch
 https://spenden.wikimedia.de/?piwik_campaign=mail-rml&piwik_kwd=confirmed
 
 -------------------------------------
-{% include 'Imprint_Address_of_Suborganization.html.twig' %}
+{% include 'Imprint_Address_of_Suborganization.txt.twig' %}
 
 Tel. 030 - 219 158 26-19
 E-Mail spenden@wikimedia.de

--- a/templates/Mail_Subscription_Request.txt.twig
+++ b/templates/Mail_Subscription_Request.txt.twig
@@ -21,7 +21,7 @@ Mit freundlichen Grüßen und bestem Dank für Ihre Unterstützungsbereitschaft.
 P.S. Eine Online-Spende können Sie auf unserer Spendenseite zu jeder Zeit abschließen. https://spenden.wikimedia.de/?piwik_campaign=mail-rml&piwik_kwd=requested
 
 -------------------------------------
-{% include 'Imprint_Address_of_Suborganization.html.twig' %}
+{% include 'Imprint_Address_of_Suborganization.txt.twig' %}
 Tel. 030 - 219 158 26-19
 Email spenden@wikimedia.de
 Spendenkonto der Wikimedia Foerdergesellschaft

--- a/templates/Privacy_Protection_Content.html.twig
+++ b/templates/Privacy_Protection_Content.html.twig
@@ -57,7 +57,9 @@
 	<p>
 		<strong>Verfahrensverzeichnis</strong><br />
 		<u>Verantwortliche Stelle</u><br />
-		{% include 'Imprint_Address_of_Suborganization.html.twig' with { output: 'html' } %}
+		{% filter nl2br %}
+			{%- include 'Imprint_Address_of_Suborganization.txt.twig' %}
+		{% endfilter %}
 		<br />
 		<u>{% include 'Imprint_Title_Head_of_Suborganization.html.twig' %}</u><br />
 		{% include 'Imprint_Name_Head_of_Suborganization.html.twig' %}<br /><br />


### PR DESCRIPTION
The address template is used in plain text mails and HTML format.
I've renamed the suffix to txt to make it more obvious that it contains
text only and use the `nl2br` filter tag when including it in HTML.