### PR TITLE
track outgoing links on embedded membership form

### DIFF
--- a/ab_test/b/templates/Membership_Application_Embedded_No_Phone.html.twig
+++ b/ab_test/b/templates/Membership_Application_Embedded_No_Phone.html.twig
@@ -1,5 +1,6 @@
 {% set showMembershipTypeOption = false %}
 {% set formSlideOpen = true %}
+{% set trackOutgoingLinks = true %}
 {% if person.salutation and person.lastName %}
 	{% set membershipAppeal = "#{person.salutation} #{person.lastName}, werden Sie Fördermitglied!" %}
 {% else %}

--- a/templates/Membership_Application_Embedded.html.twig
+++ b/templates/Membership_Application_Embedded.html.twig
@@ -1,5 +1,6 @@
 {% set showMembershipTypeOption = false %}
 {% set formSlideOpen = true %}
+{% set trackOutgoingLinks = true %}
 {% if person.salutation and person.lastName %}
 	{% set membershipAppeal = "#{person.salutation} #{person.lastName}, werden Sie Fördermitglied!" %}
 {% else %}

--- a/templates/Membership_Application_Form.html.twig
+++ b/templates/Membership_Application_Form.html.twig
@@ -60,8 +60,7 @@
 						<strong>Mehr Informationen</strong>
 					</p>
 					<p>
-						Erfahren Sie <a href="http://wikimedia.de/wiki/Mitgliedschaft" target="_blank">mehr</a>
-						&uuml;ber Wikimedia Deutschland e. V. und seine Aktivit&auml;ten.
+						Erfahren Sie <a href="http://wikimedia.de/wiki/Mitgliedschaft{% if trackOutgoingLinks is defined and trackOutgoingLinks == true %}?piwik_campaign=Spendenseite&piwik_kwd=membership-form-sidebar{% endif %}" target="_blank">mehr</a>
 					</p>
 				</div>
 			</div>
@@ -451,7 +450,7 @@
 						<span class="icon-angle-left"></span>Zur&uuml;ck zur Wikipedia
 					</a>
 
-					<a href="http://wikimedia.de" class="f-right">
+					<a href="http://wikimedia.de{% if trackOutgoingLinks is defined and trackOutgoingLinks == true %}?piwik_campaign=Spendenseite&piwik_kwd=membership-form-bottom{% endif %}" class="f-right">
 						Mehr Infos zu Wikimedia<span class="icon-angle-right _icon-right"></span>
 					</a>
 				</div>


### PR DESCRIPTION
The fundraising team wants the links leading to wikimedia.de to be tracked, but only on the donation confirmation pages embedding the membership form.

(see wmde/fundraising#1076)