### PR TITLE
T184187 remove obsolete translation key

### DIFF
--- a/i18n/de_DE/messages/messages.json
+++ b/i18n/de_DE/messages/messages.json
@@ -13,7 +13,6 @@
   "donation_cancellation_failed_text": "Ihre Spende mit der Nummer %donation.id% konnte nicht storniert werden. Bitte wenden Sie sich an <a href=\"mailto:%mailto_link%\">spenden@wikimedia.de</a>, um gegebenenfalls eine Rückbuchung zu veranlassen.",
   "donation_cancellation_mail_delivery_failure": "Die Stornierung der Spende war erfolgreich, beim Versenden der E-Mail zur Bestätigung ist aber ein Fehler aufgetreten.",
   "donation-no-donation-receipt": "Nein, ich benötige keine Spendenbescheinigung.",
-  "donation-info-opt-in": "Ja, ich möchte wissen, ob die Spendenkampagne erfolgreich war. Bitte informiert mich auch in Zukunft, wenn Wikipedia meine Hilfe braucht.",
   "donation-confirm-sepa-shortterm": "Mit SEPA wurde eine Informationsfrist für Lastschriften eingeführt. Ich bin damit einverstanden, dass ich spätestens 2 Tage vor der geplanten Abbuchung der Spende per Email benachrichtigt werde.",
   "membership-form-pledge-header": "Ich werde ab 2018 Mitglied des Wikimedia Deutschland e. V.",
   "membership-form-pledge-sustaining-member-header": "Ich werde ab 2018 Fördermitglied des Wikimedia Deutschland e. V.",


### PR DESCRIPTION
After https://github.com/wmde/FundraisingFrontend/pull/1171 is safely deployed
to production. Seems to be the case since 2018-01-16T14:49:40+02:00