### PR TITLE
Add json key validator

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3,7 +3,7 @@ kind: pipeline
 type: docker
 name: default
 
-triggers:
+trigger:
   branch:
     - test
     - production

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 vendor/
 composer.lock
 secrets.txt
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 
-php: 7.4
+php: 8.0
 
 sudo: false
 

--- a/composer.json
+++ b/composer.json
@@ -2,9 +2,13 @@
     "name": "wmde/fundraising-frontend-content",
     "description": "i18n for FundraisingFrontend",
     "license": "CC0-1.0",
+    "require": {
+        "php": ">=8.0"
+    },
     "require-dev": {
         "wmde/fundraising-content-provider": "^2.0",
-        "seld/jsonlint": "^1.6"
+        "seld/jsonlint": "^1.6",
+        "phpunit/phpunit": "~9.5.0"
     },
     "repositories": [
         {
@@ -13,6 +17,11 @@
             "no-api": true
         }
     ],
+    "autoload-dev": {
+        "psr-4": {
+            "WMDE\\Fundraising\\Content\\Tests\\": "tests/"
+        }
+    },
     "scripts": {
         "ci": [
             "@test"
@@ -21,7 +30,8 @@
             "composer validate --no-interaction",
             "@lint-json",
             "@lint-templates",
-            "@lint-wordlists"
+            "@lint-wordlists",
+            "vendor/bin/phpunit"
         ],
         "lint-json": [
             "find i18n/ -type f -name \\*.json -exec echo \"{}\" \\; -exec vendor/bin/jsonlint {} \\;"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<phpunit
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+        backupGlobals="false"
+        backupStaticAttributes="false"
+        bootstrap="tests/bootstrap.php"
+        colors="true"
+        convertErrorsToExceptions="true"
+        convertNoticesToExceptions="false"
+        convertWarningsToExceptions="true"
+        stopOnError="false"
+        stopOnFailure="false"
+        stopOnIncomplete="false"
+        stopOnSkipped="false"
+        verbose="false"
+>
+    <testsuites>
+        <testsuite name="unit">
+            <directory>tests/Validation</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/Fixtures/JsonValidator.php
+++ b/tests/Fixtures/JsonValidator.php
@@ -17,10 +17,17 @@ class JsonValidator {
 	}
 
 	public function assertJsonFilesHaveMatchingKeys( string $jsonFilePathA, $jsonFilePathB ): void {
+		$jsonKeysFromA = $this->getJsonKeys( $jsonFilePathA );
+		$jsonKeysFromB = $this->getJsonKeys( $jsonFilePathB );
 		$this->testCase->assertSame(
 			[],
-			array_diff( $this->getJsonKeys( $jsonFilePathA ), $this->getJsonKeys( $jsonFilePathB ) ),
-			"Array keys do not exists in both files"
+			array_diff( $jsonKeysFromA, $jsonKeysFromB ),
+			"$jsonFilePathB has missing keys"
+		);
+		$this->testCase->assertSame(
+			[],
+			array_diff( $jsonKeysFromB, $jsonKeysFromA ),
+			"$jsonFilePathB has additional keys that don't exist in $jsonFilePathA"
 		);
 	}
 

--- a/tests/Fixtures/JsonValidator.php
+++ b/tests/Fixtures/JsonValidator.php
@@ -1,0 +1,34 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\Content\Tests\Fixtures;
+
+use PHPUnit\Framework\TestCase;
+
+class JsonValidator {
+
+	private TestCase $testCase;
+	private string $basePath;
+
+	public function __construct( TestCase $testCase ) {
+		$this->testCase = $testCase;
+		$this->basePath = __DIR__ . '/../../';
+	}
+
+	public function assertJsonFilesHaveMatchingKeys( string $jsonFilePathA, $jsonFilePathB ): void {
+		$this->testCase->assertSame(
+			[],
+			array_diff( $this->getJsonKeys( $jsonFilePathA ), $this->getJsonKeys( $jsonFilePathB ) ),
+			"Array keys do not exists in both files"
+		);
+	}
+
+	private function getJsonKeys( string $path ): array {
+		$file = file_get_contents( $this->basePath . $path );
+		$data = json_decode( $file, true );
+		$filteredData = array_filter( $data, fn( $value ) => $value !== "" );
+
+		return array_keys( $filteredData );
+	}
+}

--- a/tests/Validation/MessagesTest.php
+++ b/tests/Validation/MessagesTest.php
@@ -23,7 +23,6 @@ class MessagesTest extends TestCase {
 	public function messageKeysDataProvider(): array {
 		return [
 			[ 'i18n/de_DE/messages/messages.json', 'i18n/de_DE/messages/messages.json' ],
-			[ 'i18n/de_DE/messages/messages.json', 'i18n/de_DE/messages/messages_laika.json' ],
 		];
 	}
 }

--- a/tests/Validation/MessagesTest.php
+++ b/tests/Validation/MessagesTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\Content\Tests\Validation;
+
+use PHPUnit\Framework\TestCase;
+use WMDE\Fundraising\Content\Tests\Fixtures\JsonValidator;
+
+class MessagesTest extends TestCase {
+
+	private JsonValidator $jsonValidator;
+
+	protected function setUp(): void {
+		$this->jsonValidator = new JsonValidator( $this );
+	}
+
+	/** @dataProvider messageKeysDataProvider */
+	public function testMessagesKeysMatch( string $jsonFileA, string $jsonFileB): void {
+		$this->jsonValidator->assertJsonFilesHaveMatchingKeys( $jsonFileA, $jsonFileB );
+	}
+
+	public function messageKeysDataProvider(): array {
+		return [
+			[ 'i18n/de_DE/messages/messages.json', 'i18n/de_DE/messages/messages.json' ],
+			[ 'i18n/de_DE/messages/messages.json', 'i18n/de_DE/messages/messages_laika.json' ],
+		];
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,16 @@
+<?php
+
+declare( strict_types = 1 );
+
+if ( PHP_SAPI !== 'cli' ) {
+	die( 'Not an entry point' );
+}
+
+error_reporting( -1 );
+ini_set( 'display_errors', '1' );
+
+if ( !is_readable( __DIR__ . '/../vendor/autoload.php' ) ) {
+	die( 'You need to install this package with Composer before you can run the tests' );
+}
+
+require __DIR__ . '/../vendor/autoload.php';


### PR DESCRIPTION
We are about to add English localisation so we need to make sure that the different translation files stay in sync.

Ticket: https://phabricator.wikimedia.org/T256614

I decided to use PhpUnit for the following reasons:
* We are already comfortable with it
* We already have composer packages in this project
* It gIves us easy CLI output out of the box
* Easy to add more validations (eg can add new languages to the data providers)
* Less custom code to maintain