### PR TITLE
Use two-way array_diff for JSON key check

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3,7 +3,7 @@ kind: pipeline
 type: docker
 name: default
 
-triggers:
+trigger:
   branch:
     - test
     - production

--- a/tests/Fixtures/JsonValidator.php
+++ b/tests/Fixtures/JsonValidator.php
@@ -17,10 +17,17 @@ class JsonValidator {
 	}
 
 	public function assertJsonFilesHaveMatchingKeys( string $jsonFilePathA, $jsonFilePathB ): void {
+		$jsonKeysFromA = $this->getJsonKeys( $jsonFilePathA );
+		$jsonKeysFromB = $this->getJsonKeys( $jsonFilePathB );
 		$this->testCase->assertSame(
 			[],
-			array_diff( $this->getJsonKeys( $jsonFilePathA ), $this->getJsonKeys( $jsonFilePathB ) ),
-			"Array keys do not exists in both files"
+			array_diff( $jsonKeysFromA, $jsonKeysFromB ),
+			"$jsonFilePathB has missing keys"
+		);
+		$this->testCase->assertSame(
+			[],
+			array_diff( $jsonKeysFromB, $jsonKeysFromA ),
+			"$jsonFilePathB has additional keys that don't exist in $jsonFilePathA"
 		);
 	}
 


### PR DESCRIPTION
Check for missing and superfluous keys. This check assumes, that we'll
have one "default" set of messages that all other messages are compared
against.