### PR TITLE
Clean up containers in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,15 +3,15 @@ BUILD_DIR     := $(PWD)
 setup: install
 
 install:
-	docker run -v $(BUILD_DIR):/app -w /app composer install
+	docker run --rm -v $(BUILD_DIR):/app -w /app composer install
 
 update:
-	docker run -v $(BUILD_DIR):/app -w /app composer update
+	docker run --rm -v $(BUILD_DIR):/app -w /app composer update
 
 ci:
-	docker run -v $(BUILD_DIR):/app -w /app composer ci
+	docker run --rm -v $(BUILD_DIR):/app -w /app composer ci
 
 test:
-	docker run -v $(BUILD_DIR):/app -w /app composer test
+	docker run --rm -v $(BUILD_DIR):/app -w /app composer test
 
 .PHONY: setup test ci install update


### PR DESCRIPTION
Add --rm flag to each docker command to remove the stopped containers
after the task has finished.