### PR TITLE
Group address type messages into their AB test contexts

### DIFF
--- a/i18n/de_DE/messages/messages.json
+++ b/i18n/de_DE/messages/messages.json
@@ -129,20 +129,85 @@
   "donation_form_academic_title_label": "Titel",
   "donation_form_academic_title_option_none": "Kein Titel",
 
-  "donation_form_provisional_address_choice_title": "Möchten Sie Ihre Kontaktdaten angeben?",
-  "donation_form_provisional_address_choice_fulladdress": "Vollständige Kontaktdaten",
-  "donation_form_provisional_address_choice_fulladdress_notice": "(für Spendenquittung per Post und Bestätigung per E-Mail)",
-  "donation_form_provisional_address_choice_emailonly": "Nur E-Mail-Adresse",
-  "donation_form_provisional_address_choice_emailonly_notice": "(für Bestätigung per E-Mail)",
-  "donation_form_provisional_address_choice_noaddress": "Gar keine Kontaktdaten",
+
+
+
+
+
+
+
+  "donation_form_address_choice_title_addresstype": "Möchten Sie Ihre Kontaktdaten angeben?",
+  "donation_form_address_choice_direct_debit_disclaimer_addresstype": "Für Lastschriften ist die Angabe einer Adresse erforderlich.",
+  "donation_form_address_choice_fulladdress_addresstype": "Vollständige Kontaktdaten",
+  "donation_form_address_choice_fulladdress_notice_addresstype": "(für Spendenquittung per Post und Bestätigung per E-Mail)",
+  "donation_form_address_choice_emailonly_addresstype": "Nur E-Mail-Adresse",
+  "donation_form_address_choice_emailonly_notice_addresstype": "(für Bestätigung per E-Mail)",
+  "donation_form_address_choice_noaddress_addresstype": "Gar keine Kontaktdaten",
+  "donation_form_section_address_header_type_addresstype": "Spenden als...",
+  "donation_form_addresstype_option_private_addresstype": "Privatperson",
+  "donation_form_addresstype_option_company_addresstype": "Firma",
+
+
+  "donation_form_address_choice_title_addresstype_basic": "Möchten Sie Ihre Kontaktdaten angeben?",
+  "donation_form_address_choice_direct_debit_disclaimer_addresstype_basic": "Für Lastschriften ist die Angabe einer Adresse erforderlich.",
+  "donation_form_addresstype_option_private_addresstype_basic": "Privatperson",
+  "donation_form_addresstype_option_company_addresstype_basic": "Firma",
+  "donation_form_addresstype_option_anonymous_addresstype_basic": "Ohne Adressangabe",
+
+
+  "donation_form_provisional_address_choice_title_addresstype_var": "Sie bestimmen, ob und welche Kontaktdaten Sie angeben.",
+  "donation_form_provisional_address_choice_title_notice_addresstype_var": "Wir melden uns grundsätzlich nur ganz selten. Und dann nur, um zu informieren, wenn Wikipedia wieder Hilfe braucht.",
+  "donation_form_address_choice_direct_debit_disclaimer_addresstype_var":  "Für Lastschriften ist die Angabe einer Adresse erforderlich.",
+  "donation_form_provisional_address_choice_fulladdress_addresstype_var": "Vollständige Kontaktdaten",
+  "donation_form_provisional_address_choice_fulladdress_notice_addresstype_var": "Nur so können wir Ihnen eine Spendenquittung per Post zusenden. Außerdem erhalten Sie eine Bestätigung per E-Mail.",
+  "donation_form_provisional_address_choice_emailonly_addresstype_var": "Nur E-Mail-Adresse",
+  "donation_form_provisional_address_choice_emailonly_notice_addresstype_var": "Sie verzichten auf eine Spendenquittung, erhalten aber eine Bestätigung per E-Mail.",
+  "donation_form_provisional_address_choice_noaddress_addresstype_var": "Gar keine Kontaktdaten",
+  "donation_form_provisional_address_choice_noaddress_notice_addresstype_var": "Sie verzichten sowohl auf eine Spendenquittung als auch auf eine Bestätigung per E-Mail. Sie erhalten von uns keine Information, wenn Wikipedia wieder Hilfe braucht.",
+  "donation_form_section_address_header_type_addresstype_var": "Spenden als...",
+  "donation_form_addresstype_option_private_addresstype_var": "Privatperson",
+  "donation_form_addresstype_option_company_addresstype_var": "Firma",
+
+
+  "C21_WMDE_Test_15_header_addresstype_checkmarks": "Was ist Ihre bevorzugte Kontaktmethode?",
+  "C21_WMDE_Test_15_full_title_addresstype_checkmarks": "Vollständige Kontaktdaten",
+  "C21_WMDE_Test_15_full_line_1_addresstype_checkmarks": "Bestätigung per E-Mail",
+  "C21_WMDE_Test_15_full_line_2_addresstype_checkmarks": "Spendenquittung per Post",
+  "C21_WMDE_Test_15_email_title_addresstype_checkmarks": "Nur E-Mail-Adresse",
+  "C21_WMDE_Test_15_email_line_1_addresstype_checkmarks": "Bestätigung per E-Mail",
+  "C21_WMDE_Test_15_email_line_2_addresstype_checkmarks": "Keine Spendenquittung",
+  "C21_WMDE_Test_15_none_title_addresstype_checkmarks": "keine Kontaktaufnahme",
+  "C21_WMDE_Test_15_none_line_1_addresstype_checkmarks": "Keine Bestätigung per E-Mail",
+  "C21_WMDE_Test_15_none_line_2_addresstype_checkmarks": "Keine Spendenquittung",
+  "donation_form_section_address_header_type_addresstype_checkmarks": "Spenden als...",
+  "donation_form_addresstype_option_private_addresstype_checkmarks": "Privatperson",
+  "donation_form_addresstype_option_company_addresstype_checkmarks": "Firma",
+
+
+  "donation_form_provisional_address_choice_title_addresstype_no_anon": "Sie bestimmen, ob und welche Kontaktdaten Sie angeben.",
+  "donation_form_provisional_address_choice_title_notice_addresstype_no_anon": "Wir melden uns grundsätzlich nur ganz selten. Und dann nur, um zu informieren, wenn Wikipedia wieder Hilfe braucht.",
+  "donation_form_address_choice_direct_debit_disclaimer_addresstype_no_anon": "Für Lastschriften ist die Angabe einer Adresse erforderlich.",
+  "donation_form_provisional_address_choice_fulladdress_addresstype_no_anon": "Vollständige Kontaktdaten",
+  "donation_form_provisional_address_choice_fulladdress_notice_addresstype_no_anon": "Nur so können wir Ihnen eine Spendenquittung per Post zusenden. Außerdem erhalten Sie eine Bestätigung per E-Mail.",
+  "donation_form_provisional_address_choice_emailonly_addresstype_no_anon": "Nur E-Mail-Adresse",
+  "donation_form_provisional_address_choice_emailonly_notice_addresstype_no_anon": "Sie verzichten auf eine Spendenquittung, erhalten aber eine Bestätigung per E-Mail.",
+  "donation_form_section_address_header_type_addresstype_no_anon": "Spenden als...",
+  "donation_form_addresstype_option_private_addresstype_no_anon": "Privatperson",
+  "donation_form_addresstype_option_company_addresstype_no_anon": "Firma",
+
+
+
+
+
+
+
+
 
   "donation_confirmation_inline_summary_address": "<em>Sie spenden:</em> <strong>{interval} {formattedAmount}</strong> via <strong>{paymentType}</strong> {personType}<br><em>Adresse:</em> {address}<br><em>Email:</em> {email}",
   "donation_confirmation_inline_summary_email": "<em>Sie spenden:</em> <strong>{interval} {formattedAmount}</strong> via <strong>{paymentType}</strong> {personType}<br><em>Email:</em> {email}",
   "donation_confirmation_inline_summary_anonymous": "<em>Sie spenden:</em> <strong>{interval} {formattedAmount}</strong> via <strong>{paymentType}</strong> {personType}",
 
-  "donation_form_addresstype_option_anonymous": "Ohne Adressangabe",
-  "donation_form_address_choice_no": "Nein",
-  "donation_form_address_choice_yes": "Ja",
+
   "donation_addresstype_option_anonymous_disclaimer": "Ihre Kontaktdaten benötigen wir für die Bestätigungsemail und Ihre Spendenquittung. Zudem können wir Sie informieren, wenn Wikipedia in Zukunft Ihre Hilfe benötigt.",
   "donation_form_address_choice_direct_debit_disclaimer": "Für Lastschriften ist die Angabe einer Adresse erforderlich.",
   "donation_form_addresstype_option_company": "Firma",
@@ -337,24 +402,6 @@
   "donation_confirmation_summary_title_alt": "Sie erhalten Ihre Spendenquittung an folgende Adresse:",
   "donation_confirmation_topbox_summary_alt": "Sie spenden:<br><strong>{interval}</strong><br><strong>{formattedAmount}</strong> via<br><strong>{paymentType}</strong> <br>{personType}<br>{address}<br>",
   "donation_confirmation_cta_title_alt": "Benötigen Sie eine Spendenquittung?",
-  "donation_confirmation_cta_summary_alt": "Damit wir Ihnen Ihre Spendenquittung nach Hause schicken können, benötigen wir Ihre Postadresse.",
+  "donation_confirmation_cta_summary_alt": "Damit wir Ihnen Ihre Spendenquittung nach Hause schicken können, benötigen wir Ihre Postadresse."
 
-  "donation_form_provisional_address_choice_title_var": "Sie bestimmen, ob und welche Kontaktdaten Sie angeben.",
-  "donation_form_provisional_address_choice_title_notice_var": "Wir melden uns grundsätzlich nur ganz selten. Und dann nur, um zu informieren, wenn Wikipedia wieder Hilfe braucht.",
-  "donation_form_provisional_address_choice_fulladdress_notice_var": "Nur so können wir Ihnen eine Spendenquittung per Post zusenden. Außerdem erhalten Sie eine Bestätigung per E-Mail.",
-  "donation_form_provisional_address_choice_emailonly_notice_var": "Sie verzichten auf eine Spendenquittung, erhalten aber eine Bestätigung per E-Mail.",
-  "donation_form_provisional_address_choice_noaddress_notice_var": "Sie verzichten sowohl auf eine Spendenquittung als auch auf eine Bestätigung per E-Mail. Sie erhalten von uns keine Information, wenn Wikipedia wieder Hilfe braucht.",
-
-  "C21_WMDE_Test_15_header": "Was ist Ihre bevorzugte Kontaktmethode?",
-  "C21_WMDE_Test_15_full_title": "Vollständige Kontaktdaten",
-  "C21_WMDE_Test_15_full_line_1": "Bestätigung per E-Mail",
-  "C21_WMDE_Test_15_full_line_2": "Spendenquittung per Post",
-
-  "C21_WMDE_Test_15_email_title": "Nur E-Mail-Adresse",
-  "C21_WMDE_Test_15_email_line_1": "Bestätigung per E-Mail",
-  "C21_WMDE_Test_15_email_line_2": "Keine Spendenquittung",
-
-  "C21_WMDE_Test_15_none_title": "keine Kontaktaufnahme",
-  "C21_WMDE_Test_15_none_line_1": "Keine Bestätigung per E-Mail",
-  "C21_WMDE_Test_15_none_line_2": "Keine Spendenquittung"
 }

--- a/i18n/en_GB/messages/messages.json
+++ b/i18n/en_GB/messages/messages.json
@@ -129,20 +129,88 @@
   "donation_form_academic_title_label": "Title",
   "donation_form_academic_title_option_none": "No title",
 
-  "donation_form_provisional_address_choice_title": "Would you like to enter your contact details?",
-  "donation_form_provisional_address_choice_fulladdress": "Full contact details",
-  "donation_form_provisional_address_choice_fulladdress_notice": "(for a donation receipt by post and a confirmation by email)",
-  "donation_form_provisional_address_choice_emailonly": "Email address only",
-  "donation_form_provisional_address_choice_emailonly_notice": "(for a confirmation by email)",
-  "donation_form_provisional_address_choice_noaddress": "No contact details",
+
+
+
+
+
+
+
+
+
+
+  "donation_form_address_choice_title_addresstype": "Would you like to enter your contact details?",
+  "donation_form_address_choice_direct_debit_disclaimer_addresstype": "For direct debit payments, full address details are mandatory.",
+  "donation_form_address_choice_fulladdress_addresstype": "Full contact details",
+  "donation_form_address_choice_fulladdress_notice_addresstype": "(for a donation receipt by post and a confirmation by email)",
+  "donation_form_address_choice_emailonly_addresstype": "Email address only",
+  "donation_form_address_choice_emailonly_notice_addresstype": "(for a confirmation by email)",
+  "donation_form_address_choice_noaddress_addresstype": "No contact details",
+  "donation_form_section_address_header_type_addresstype": "Donate as ...",
+  "donation_form_addresstype_option_private_addresstype": "Yes, as a private individual",
+  "donation_form_addresstype_option_company_addresstype": "Yes, as a representative of an organization",
+
+
+  "donation_form_address_choice_title_addresstype_basic": "Would you like to enter your contact details?",
+  "donation_form_address_choice_direct_debit_disclaimer_addresstype_basic": "For direct debit payments, full address details are mandatory.",
+  "donation_form_addresstype_option_private_addresstype_basic": "Yes, as a private individual",
+  "donation_form_addresstype_option_company_addresstype_basic": "Yes, as a representative of an organization",
+  "donation_form_addresstype_option_anonymous_addresstype_basic": "No",
+
+
+  "donation_form_provisional_address_choice_title_addresstype_var": "You determine which contact details you provide.",
+  "donation_form_provisional_address_choice_title_notice_addresstype_var": "We rarely get in touch. When we do, it's only to inform you when Wikipedia once again needs your help.",
+  "donation_form_address_choice_direct_debit_disclaimer_addresstype_var":  "For direct debit payments, full address details are mandatory.",
+  "donation_form_provisional_address_choice_fulladdress_addresstype_var": "Full contact details",
+  "donation_form_provisional_address_choice_fulladdress_notice_addresstype_var": "You will receive a donation receipt by mail. You will also receive an e-mail confirmation of your donation.",
+  "donation_form_provisional_address_choice_emailonly_addresstype_var": "Email address only",
+  "donation_form_provisional_address_choice_emailonly_notice_addresstype_var": "You waive the donation receipt, but receive an e-mail confirmation of your donation.",
+  "donation_form_provisional_address_choice_noaddress_addresstype_var": "No contact details",
+  "donation_form_provisional_address_choice_noaddress_notice_addresstype_var": "You waive the donation receipt and an e-mail confirmation of your donation. We will not contact you when Wikipedia needs help again.",
+  "donation_form_section_address_header_type_addresstype_var": "Donate as ...",
+  "donation_form_addresstype_option_private_addresstype_var": "Yes, as a private individual",
+  "donation_form_addresstype_option_company_addresstype_var": "Yes, as a representative of an organization",
+
+
+  "C21_WMDE_Test_15_header_addresstype_checkmarks": "What's your preferred contact method?",
+  "C21_WMDE_Test_15_full_title_addresstype_checkmarks": "Full contact details",
+  "C21_WMDE_Test_15_full_line_1_addresstype_checkmarks": "Confirmation by email",
+  "C21_WMDE_Test_15_full_line_2_addresstype_checkmarks": "Donation receipt by post",
+  "C21_WMDE_Test_15_email_title_addresstype_checkmarks": "Email address only",
+  "C21_WMDE_Test_15_email_line_1_addresstype_checkmarks": "Confirmation by email",
+  "C21_WMDE_Test_15_email_line_2_addresstype_checkmarks": "No donation receipt",
+  "C21_WMDE_Test_15_none_title_addresstype_checkmarks": "No contact details",
+  "C21_WMDE_Test_15_none_line_1_addresstype_checkmarks": "No email confirmation",
+  "C21_WMDE_Test_15_none_line_2_addresstype_checkmarks": "No donation receipt",
+  "donation_form_section_address_header_type_addresstype_checkmarks": "Donate as ...",
+  "donation_form_addresstype_option_private_addresstype_checkmarks": "Yes, as a private individual",
+  "donation_form_addresstype_option_company_addresstype_checkmarks": "Yes, as a representative of an organization",
+
+
+  "donation_form_provisional_address_choice_title_addresstype_no_anon": "You determine which contact details you provide.",
+  "donation_form_provisional_address_choice_title_notice_addresstype_no_anon": "We rarely get in touch. When we do, it's only to inform you when Wikipedia once again needs your help.",
+  "donation_form_address_choice_direct_debit_disclaimer_addresstype_no_anon": "For direct debit payments, full address details are mandatory.",
+  "donation_form_provisional_address_choice_fulladdress_addresstype_no_anon": "Full contact details",
+  "donation_form_provisional_address_choice_fulladdress_notice_addresstype_no_anon": "You will receive a donation receipt by mail. You will also receive an e-mail confirmation of your donation.",
+  "donation_form_provisional_address_choice_emailonly_addresstype_no_anon": "Email address only",
+  "donation_form_provisional_address_choice_emailonly_notice_addresstype_no_anon": "You waive the donation receipt, but receive an e-mail confirmation of your donation.",
+  "donation_form_section_address_header_type_addresstype_no_anon": "Donate as ...",
+  "donation_form_addresstype_option_private_addresstype_no_anon": "Yes, as a private individual",
+  "donation_form_addresstype_option_company_addresstype_no_anon": "Yes, as a representative of an organization",
+
+
+
+
+
+
+
+
+
 
   "donation_confirmation_inline_summary_address": "<em>You will donate:</em> <strong>{interval} {formattedAmount}</strong> via <strong>{paymentType}</strong> {personType}<br><em>Address:</em> {address}<br><em>Email:</em> {email}",
   "donation_confirmation_inline_summary_email": "<em>You will donate:</em> <strong>{interval} {formattedAmount}</strong> via <strong>{paymentType}</strong> {personType}<br><em>Email:</em> {email}",
   "donation_confirmation_inline_summary_anonymous": "<em>You will donate:</em> <strong>{interval} {formattedAmount}</strong> via <strong>{paymentType}</strong> {personType}",
 
-  "donation_form_addresstype_option_anonymous": "No",
-  "donation_form_address_choice_no": "No",
-  "donation_form_address_choice_yes": "Yes",
   "donation_addresstype_option_anonymous_disclaimer": "We need your email to send you an email confirmation and your donation receipt. We can also inform you if and when Wikipedia needs your help in the future.",
   "donation_form_address_choice_direct_debit_disclaimer": "For direct debit payments, full address details are mandatory.",
   "donation_form_addresstype_option_company": "Yes, as a representative of an organization",
@@ -338,24 +406,5 @@
   "donation_confirmation_summary_title_alt": "We will send your donation receipt to the following address:",
   "donation_confirmation_topbox_summary_alt": "You donated:<br><strong>{interval}</strong><br><strong>EUR {formattedAmount}</strong> via<br><strong>{paymentType}</strong> <br>{personType}<br>{address}<br>",
   "donation_confirmation_cta_title_alt": "Do you need a donation receipt?",
-  "donation_confirmation_cta_summary_alt": "We need your postal address in order to send you a donation receipt.",
-
-  "donation_form_provisional_address_choice_title_var": "You determine which contact details you provide.",
-  "donation_form_provisional_address_choice_title_notice_var": "We rarely get in touch. When we do, it's only to inform you when Wikipedia once again needs your help.",
-  "donation_form_provisional_address_choice_fulladdress_notice_var": "You will receive a donation receipt by mail. You will also receive an e-mail confirmation of your donation.",
-  "donation_form_provisional_address_choice_emailonly_notice_var": "You waive the donation receipt, but receive an e-mail confirmation of your donation.",
-  "donation_form_provisional_address_choice_noaddress_notice_var": "You waive the donation receipt and an e-mail confirmation of your donation. We will not contact you when Wikipedia needs help again.",
-
-  "C21_WMDE_Test_15_header": "What's your preferred contact method?",
-  "C21_WMDE_Test_15_full_title": "Full contact details",
-  "C21_WMDE_Test_15_full_line_1": "Confirmation by email",
-  "C21_WMDE_Test_15_full_line_2": "Donation receipt by post",
-
-  "C21_WMDE_Test_15_email_title": "Email address only",
-  "C21_WMDE_Test_15_email_line_1": "Confirmation by email",
-  "C21_WMDE_Test_15_email_line_2": "No donation receipt",
-
-  "C21_WMDE_Test_15_none_title": "No contact details",
-  "C21_WMDE_Test_15_none_line_1": "No email confirmation",
-  "C21_WMDE_Test_15_none_line_2": "No donation receipt"
+  "donation_confirmation_cta_summary_alt": "We need your postal address in order to send you a donation receipt."
 }


### PR DESCRIPTION
the keys are used by 5 AB test components and namely grouped into them:
- addresstype
- addresstype_var
- addresstype_checkmarks
- addresstyoe_no_anon
- basic addresstype

Ticket: https://phabricator.wikimedia.org/T300370