### PR TITLE
Re-add the "donation_form_newsletter_label" key-value pair

### DIFF
--- a/i18n/de_DE/messages/messages.json
+++ b/i18n/de_DE/messages/messages.json
@@ -242,6 +242,7 @@
   "donation_form_lastname_label": "Name",
   "donation_form_lastname_placeholder": "Mustername",
   "donation_form_lastname_placeholder_warning": "Sind Sie sich sicher, dass Ihr Nachname Mustermann ist?",
+  "donation_form_newsletter_label": "Ja, ich möchte in Zukunft informiert werden, wenn Wikipedia meine Hilfe braucht. Die Einwilligung kann ich jederzeit per E-Mail an spenden@wikimedia.de mit Wirkung für die Zukunft widerrufen.",
   "donation_form_newsletter_label_paragraph_1": "Ja, ich möchte wissen, ob die Spendenkampagne erfolgreich war und wie meine Spende geholfen hat. Zudem dürfen Sie mich kontaktieren, wenn Wikipedia meine Hilfe braucht.",
   "donation_form_newsletter_label_paragraph_2": "Falls Sie das nicht möchten, entfernen Sie bitte das Häkchen. Sie können natürlich auch in Zukunft jederzeit widersprechen, z. B. über den Abmelde-Link am Fuß jeder Nachricht oder per E-Mail an spenden@wikimedia.de. Weitere Informationen finden Sie in unseren <a href=\"https://spenden.wikimedia.de/page/Datenschutz\">Datenschutzhinweisen</a>.",
   "donation_form_payment_amount_error": "Sie müssen aufgrund anfallender Gebühren leider einen Mindestbetrag von 1 Euro angeben. Wenn Sie weniger spenden möchten, überweisen Sie bitte direkt an das unten angegebene Spendenkonto.",

--- a/i18n/en_GB/messages/messages.json
+++ b/i18n/en_GB/messages/messages.json
@@ -244,6 +244,7 @@
   "donation_form_lastname_label": "Last Name",
   "donation_form_lastname_placeholder": "Bloggs",
   "donation_form_lastname_placeholder_warning": "Are you sure that your surname is Bloggs?",
+  "donation_form_newsletter_label": "Yes, I would like to be notified if Wikipedia needs my help in the future. I understand I can revoke my consent at any time by sending an email to spenden@wikimedia.de.",
   "donation_form_newsletter_label_paragraph_1": "Yes, I would like to know if the fundraising campaign was successful and how my donation helped. In addition, you may contact me if Wikipedia needs my help.",
   "donation_form_newsletter_label_paragraph_2": "If you do not want to receive emails, please uncheck the box. You can also unsubscribe at any time in the future, for example, via the unsubscribe link at the bottom of each email or by sending an email to spenden@wikimedia.de. You can find further information in our <a href=\"https://spenden.wikimedia.de/page/Datenschutz\">privacy policy</a>.",
   "donation_form_payment_amount_error": "Unfortunately, due to applicable fees, you have to state a minimum amount of EUR 1. If you would like to donate less, please transfer the amount directly to the donation account stated below.",


### PR DESCRIPTION
Re-add the "donation_form_newsletter_label" key-value pair in the EN and DE versions of messeges.json files.

https://phabricator.wikimedia.org/T322183