### PR TITLE
Add new syntax for @ symbols

### DIFF
--- a/i18n/de_DE/messages/messages.json
+++ b/i18n/de_DE/messages/messages.json
@@ -3,7 +3,7 @@
   "access_denied_header": "Fehler",
   "access_denied_donation_confirmation": "Sie haben keine Berechtigung, diese Spende zu sehen.",
   "access_denied_membership_confirmation": "Sie haben keine Berechtigung, diesen Mitgliedschafts-Antrag zu sehen.",
-  "access_denied_membership_confirmation_anonymized": "Ihr Mitgliedschaftsantrag wurde erfolgreich abgeschlossen, die Bestätigungsseite kann allerdings nicht mehr angezeigt werden. Fragen zu Ihrer Mitgliedschaft können Sie uns gern per E-Mail an <a href=\"mailto:mitglieder%40wikimedia.de\">mitglieder@wikimedia.de</a> stellen.",
+  "access_denied_membership_confirmation_anonymized": "Ihr Mitgliedschaftsantrag wurde erfolgreich abgeschlossen, die Bestätigungsseite kann allerdings nicht mehr angezeigt werden. Fragen zu Ihrer Mitgliedschaft können Sie uns gern per E-Mail an <a href=\"mailto:mitglieder%40wikimedia.de\">mitglieder@wikimedia.de</a> stellen.",  "access_denied_membership_confirmation_anonymized_vuei18n_v3": "Ihr Mitgliedschaftsantrag wurde erfolgreich abgeschlossen, die Bestätigungsseite kann allerdings nicht mehr angezeigt werden. Fragen zu Ihrer Mitgliedschaft können Sie uns gern per E-Mail an <a href=\"mailto:mitglieder%40wikimedia.de\">mitglieder{'@'}wikimedia.de</a> stellen.",
 
   "address_change_form_title": "Anschrift ändern",
   "address_change_form_label": "Bitte teilen Sie uns über dieses Formular Ihre aktuelle Postanschrift mit.",
@@ -11,9 +11,12 @@
   "address_change_form_success_title": "Adressänderung erfolgreich",
   "address_change_form_success_label": "Vielen Dank für Ihre Mithilfe! Sie erhalten demnächst eine Zuwendungsbescheinigung an Ihre neue Adresse.",
   "address_change_form_success_optout_label": "Vielen Dank für Ihre Mithilfe! Wir haben Ihren Wunsch keine Zuwendungsbescheinung zu erhalten vermerkt. Falls Sie Ihre Entscheidung ändern möchten, können Sie sich jederzeit per E-Mail an spenden@wikimedia.de wenden.",
+  "address_change_form_success_optout_label_vuei18n_v3": "Vielen Dank für Ihre Mithilfe! Wir haben Ihren Wunsch keine Zuwendungsbescheinung zu erhalten vermerkt. Falls Sie Ihre Entscheidung ändern möchten, können Sie sich jederzeit per E-Mail an spenden{'@'}wikimedia.de wenden.",
   "address_change_opt_out_hint": "Sie können uns Ihre aktuelle Adresse auch mitteilen, wenn Sie keine Bescheinigung erhalten möchten.",
   "address_change_no_token_in_request": "Unberechtigter Zugriff auf Adressänderung. Bitte wenden Sie sich an spenden@wikimedia.de wenn Sie einen Link zur Adressänderung haben, der nicht funktioniert.",
+  "address_change_no_token_in_request_vuei18n_v3": "Unberechtigter Zugriff auf Adressänderung. Bitte wenden Sie sich an spenden{'@'}wikimedia.de wenn Sie einen Link zur Adressänderung haben, der nicht funktioniert.",
   "address_change_token_not_found": "Adressänderung nicht möglich. Links, die Sie zur Adressänderung bekommen sind nur einmal gültig. Wenn Sie Ihre Adresse erneut korrigieren möchten, wenden Sie sich bitte per Mail an spenden@wikimedia.de oder benutzen Sie das Kontaktformular.",
+  "address_change_token_not_found_vuei18n_v3": "Adressänderung nicht möglich. Links, die Sie zur Adressänderung bekommen sind nur einmal gültig. Wenn Sie Ihre Adresse erneut korrigieren möchten, wenden Sie sich bitte per Mail an spenden{'@'}wikimedia.de oder benutzen Sie das Kontaktformular.",
 
   "back_to_donation_summary": "Zurück zur Spendenübersicht",
 
@@ -39,6 +42,7 @@
   "contact_form_error": "Bitte Überprüfen Sie die Eingaben im Kontaktformular:",
   "contact_form_email_label": "E-Mail",
   "contact_form_email_placeholder": "mustername@beispiel.de",
+  "contact_form_email_placeholder_vuei18n_v3": "mustername{'@'}beispiel.de",
   "contact_form_email_error": "Bitte geben Sie eine gültige E-Mail-Adresse an.",
   "contact_form_firstname_label": "Vorname",
   "contact_form_firstname_placeholder": "Max oder Erika",
@@ -66,6 +70,7 @@
 
   "donation_cancellation_title": "Stornierung",
   "donation_cancellation_text": "Der Spendenvorgang mit der Nummer {donation_id} wurde storniert. Wenn Sie noch Fragen haben oder uns auf Probleme hinweisen möchten, wenden Sie sich bitte an <a href=\"mailto:%mailto_link%\">spenden@wikimedia.de</a>.",
+  "donation_cancellation_text_vuei18n_v3": "Der Spendenvorgang mit der Nummer {donation_id} wurde storniert. Wenn Sie noch Fragen haben oder uns auf Probleme hinweisen möchten, wenden Sie sich bitte an <a href=\"mailto:%mailto_link%\">spenden{'@'}wikimedia.de</a>.",
 
   "donation_comment_popup_title": "Spendenkommentar schreiben",
   "donation_comment_popup_explanation": "Erzählen Sie, warum Sie gespendet haben. Was verbindet Sie mit Wikipedia? Ihre Geschichte hilft uns, den Millionen Menschen, die Wikipedia täglich nutzen, die Bedeutung Wikipedias zu veranschaulichen.",
@@ -125,6 +130,7 @@
   "donation_confirmation_inline_summary": "Sie spenden: <strong>{interval} {formattedAmount}</strong> per <strong>{paymentType}</strong>.",
   "donation_confirmation_address_usage_link": "mehr Informationen",
   "donation_confirmation_address_usage_content": "Wir benötigen Ihre Postanschrift, um Ihnen Ihre Spendenquittung zusenden zu können. Ein Versenden per e-Mail ist derzeit noch nicht sicher genug. Darüber hinaus versenden wir ab und zu Spendenbitten, wenn Wikipedia wieder Ihre Hilfe benötigt. Wenn Sie diese nicht erhalten möchten, können Sie uns dies per E-Mail an spenden@wikimedia.de formlos mitteilen. Dann bekommen Sie nur Ihre Spendenquittung nach Hause geschickt.",
+  "donation_confirmation_address_usage_content_vuei18n_v3": "Wir benötigen Ihre Postanschrift, um Ihnen Ihre Spendenquittung zusenden zu können. Ein Versenden per e-Mail ist derzeit noch nicht sicher genug. Darüber hinaus versenden wir ab und zu Spendenbitten, wenn Wikipedia wieder Ihre Hilfe benötigt. Wenn Sie diese nicht erhalten möchten, können Sie uns dies per E-Mail an spenden{'@'}wikimedia.de formlos mitteilen. Dann bekommen Sie nur Ihre Spendenquittung nach Hause geschickt.",
 
   "donation_form_academic_title_label": "Titel",
   "donation_form_academic_title_option_none": "Kein Titel",
@@ -247,6 +253,7 @@
   "donation_form_email_error": "Bitte geben Sie eine gültige E-Mail-Adresse an.",
   "donation_form_email_label": "E-Mail",
   "donation_form_email_placeholder": "mustername@beispiel.de",
+  "donation_form_email_placeholder_vuei18n_v3": "mustername{'@'}beispiel.de",
   "donation_form_email_placeholder_warning": "Sind Sie sicher, dass {value} Ihre E-Mail-Adresse ist?",
   "donation_form_email_suggestion": "Meinten Sie vielleicht",
   "donation_form_finalize": "Jetzt spenden",
@@ -259,8 +266,10 @@
   "donation_form_lastname_placeholder_check": "Mustername",
   "donation_form_lastname_placeholder_warning": "Sind Sie sich sicher, dass Ihr Nachname {value} ist?",
   "donation_form_newsletter_label": "Ja, ich möchte in Zukunft informiert werden, wenn Wikipedia meine Hilfe braucht. Die Einwilligung kann ich jederzeit per E-Mail an spenden@wikimedia.de mit Wirkung für die Zukunft widerrufen.",
+  "donation_form_newsletter_label_vuei18n_v3": "Ja, ich möchte in Zukunft informiert werden, wenn Wikipedia meine Hilfe braucht. Die Einwilligung kann ich jederzeit per E-Mail an spenden{'@'}wikimedia.de mit Wirkung für die Zukunft widerrufen.",
   "donation_form_newsletter_label_paragraph_1": "Ja, ich möchte in Zukunft informiert werden, wenn Wikipedia meine Hilfe braucht.",
   "donation_form_newsletter_label_paragraph_2": "Falls Sie das nicht möchten, entfernen Sie bitte das Häkchen. Sie können natürlich auch in Zukunft jederzeit widersprechen, z. B. über den Abmelde-Link am Fuß jeder Nachricht oder per E-Mail an spenden@wikimedia.de. Weitere Informationen finden Sie in unseren <a href=\"https://spenden.wikimedia.de/page/Datenschutz\">Datenschutzhinweisen</a>.",
+  "donation_form_newsletter_label_paragraph_2_vuei18n_v3": "Falls Sie das nicht möchten, entfernen Sie bitte das Häkchen. Sie können natürlich auch in Zukunft jederzeit widersprechen, z. B. über den Abmelde-Link am Fuß jeder Nachricht oder per E-Mail an spenden{'@'}wikimedia.de. Weitere Informationen finden Sie in unseren <a href=\"https://spenden.wikimedia.de/page/Datenschutz\">Datenschutzhinweisen</a>.",
   "donation_form_payment_amount_error": "Sie müssen aufgrund anfallender Gebühren leider einen Mindestbetrag von 1 Euro angeben. Wenn Sie weniger spenden möchten, überweisen Sie bitte direkt an das unten angegebene Spendenkonto.",
   "donation_form_payment_amount_too_high": "Es darf nicht mehr als 99999 € sein.",
   "donation_form_payment_amount_legend": "Bitte geben Sie Ihren Wunschbetrag an.",
@@ -331,6 +340,7 @@
 
   "membership_cancellation_title": "Ihr Mitgliedschaftsantrag wurde storniert",
   "membership_cancellation_text": "Ihr Mitgliedschaftsantrag mit der Nummer {membership_id} wurde storniert. Wenn Sie noch Fragen haben oder uns auf Probleme hinweisen möchten, wenden Sie sich bitte an <a href=\"mailto:%mailto_link%\">mitglieder@wikimedia.de</a>.",
+  "membership_cancellation_text_vuei18n_v3": "Ihr Mitgliedschaftsantrag mit der Nummer {membership_id} wurde storniert. Wenn Sie noch Fragen haben oder uns auf Probleme hinweisen möchten, wenden Sie sich bitte an <a href=\"mailto:%mailto_link%\">mitglieder{'@'}wikimedia.de</a>.",
 
   "membership_confirmation_thanks_text": "Vielen Dank für Ihr Engagement!",
   "membership_confirmation_data_text": "Sie werden <strong>{membershipType}</strong> bei Wikimedia Deutschland e. V.<br>und zahlen <strong>{membershipFeeFormatted} {paymentInterval}</strong> {membershipFeeYearlyFormatted} per <strong>{paymentType}</strong><br>als {address}",

--- a/i18n/de_DE/messages/messages.json
+++ b/i18n/de_DE/messages/messages.json
@@ -6,7 +6,8 @@
   "access_denied_header": "Fehler",
   "access_denied_donation_confirmation": "Sie haben keine Berechtigung, diese Spende zu sehen.",
   "access_denied_membership_confirmation": "Sie haben keine Berechtigung, diesen Mitgliedschafts-Antrag zu sehen.",
-  "access_denied_membership_confirmation_anonymized": "Ihr Mitgliedschaftsantrag wurde erfolgreich abgeschlossen, die Bestätigungsseite kann allerdings nicht mehr angezeigt werden. Fragen zu Ihrer Mitgliedschaft können Sie uns gern per E-Mail an <a href=\"mailto:mitglieder%40wikimedia.de\">mitglieder@wikimedia.de</a> stellen.",  "access_denied_membership_confirmation_anonymized_vuei18n_v3": "Ihr Mitgliedschaftsantrag wurde erfolgreich abgeschlossen, die Bestätigungsseite kann allerdings nicht mehr angezeigt werden. Fragen zu Ihrer Mitgliedschaft können Sie uns gern per E-Mail an <a href=\"mailto:mitglieder%40wikimedia.de\">mitglieder{'@'}wikimedia.de</a> stellen.",
+  "access_denied_membership_confirmation_anonymized": "Ihr Mitgliedschaftsantrag wurde erfolgreich abgeschlossen, die Bestätigungsseite kann allerdings nicht mehr angezeigt werden. Fragen zu Ihrer Mitgliedschaft können Sie uns gern per E-Mail an <a href=\"mailto:mitglieder%40wikimedia.de\">mitglieder@wikimedia.de</a> stellen.",
+  "access_denied_membership_confirmation_anonymized_vuei18n_v3": "Ihr Mitgliedschaftsantrag wurde erfolgreich abgeschlossen, die Bestätigungsseite kann allerdings nicht mehr angezeigt werden. Fragen zu Ihrer Mitgliedschaft können Sie uns gern per E-Mail an <a href=\"mailto:mitglieder%40wikimedia.de\">mitglieder{'@'}wikimedia.de</a> stellen.",
 
   "address_change_form_title": "Anschrift ändern",
   "address_change_form_label": "Bitte teilen Sie uns über dieses Formular Ihre aktuelle Postanschrift mit.",

--- a/i18n/de_DE/messages/messages.json
+++ b/i18n/de_DE/messages/messages.json
@@ -1,4 +1,7 @@
 {
+  "yes": "Ja",
+  "no": "Nein",
+
   "access_denied": "Sie haben keine Berechtigung, diese Seite zu sehen.",
   "access_denied_header": "Fehler",
   "access_denied_donation_confirmation": "Sie haben keine Berechtigung, diese Spende zu sehen.",

--- a/i18n/en_GB/messages/messages.json
+++ b/i18n/en_GB/messages/messages.json
@@ -4,6 +4,7 @@
   "access_denied_donation_confirmation": "You are not authorised to view this donation.",
   "access_denied_membership_confirmation": "You are not authorised to view this membership application.",
   "access_denied_membership_confirmation_anonymized": "Your membership application was completed successfully, but the confirmation page can no longer be displayed. If you have any questions concerning your membership, please contact us by email at <a href=\"mailto:mitglieder%40wikimedia.de\">mitglieder@wikimedia.de</a>.",
+  "access_denied_membership_confirmation_anonymized_vuei18n_v3": "Your membership application was completed successfully, but the confirmation page can no longer be displayed. If you have any questions concerning your membership, please contact us by email at <a href=\"mailto:mitglieder%40wikimedia.de\">mitglieder{'@'}wikimedia.de</a>.",
 
   "address_change_form_title": "Change address",
   "address_change_form_label": "Please use this contact form to send us your current address.",
@@ -11,9 +12,12 @@
   "address_change_form_success_title": "Change of address completed successfully",
   "address_change_form_success_label": "Thank you for your assistance! You will receive a donation receipt at your new address soon.",
   "address_change_form_success_optout_label": "Thank you for your assistance! You have asked not to receive a donation receipt. Should you change your mind, you can notify us by emailing spenden@wikimedia.de.",
+  "address_change_form_success_optout_label_vuei18n_v3": "Thank you for your assistance! You have asked not to receive a donation receipt. Should you change your mind, you can notify us by emailing spenden{'@'}wikimedia.de.",
   "address_change_opt_out_hint": "You can provide your current address even if you prefer not to receive a donation receipt.",
   "address_change_no_token_in_request": "Address change not authorised. If the link to update your address is not working, use our contact form or email us at spenden@wikimedia.de.",
+  "address_change_no_token_in_request_vuei18n_v3": "Address change not authorised. If the link to update your address is not working, use our contact form or email us at spenden{'@'}wikimedia.de.",
   "address_change_token_not_found": "Link expired. Address-change links only work once. Should you wish to make further changes, use our contact form or email us at spenden@wikimedia.de.",
+  "address_change_token_not_found_vuei18n_v3": "Link expired. Address-change links only work once. Should you wish to make further changes, use our contact form or email us at spenden{'@'}wikimedia.de.",
 
   "back_to_donation_summary": "Back to donation summary",
 
@@ -39,12 +43,13 @@
   "contact_form_error": "Please review your form input.",
   "contact_form_email_label": "Email",
   "contact_form_email_placeholder": "bloggs@example.com",
+  "contact_form_email_placeholder_vuei18n_v3": "bloggs{'@'}example.com",
   "contact_form_email_error": "Please enter a valid email address.",
   "contact_form_firstname_label": "First name",
   "contact_form_firstname_placeholder": "Joe or Jane",
   "contact_form_firstname_error": "Please enter your first name.",
   "contact_form_lastname_label": "Surname",
-  "contact_form_lastname_placeholder": "Bloggs@",
+  "contact_form_lastname_placeholder": "Bloggs",
   "contact_form_lastname_error": "Please enter your surname.",
   "contact_form_optional": "(optional)",
   "contact_form_subject_label": "Subject",
@@ -66,6 +71,7 @@
 
   "donation_cancellation_title": "Cancellation",
   "donation_cancellation_text": "The donation process with the number {donation_id} was cancelled. If you have any questions or would like to inform us about any problems, please contact <a href=\"mailto:%mailto_link%\">spenden@wikimedia.de</a>.",
+  "donation_cancellation_text_vuei18n_v3": "The donation process with the number {donation_id} was cancelled. If you have any questions or would like to inform us about any problems, please contact <a href=\"mailto:%mailto_link%\">spenden{'@'}wikimedia.de</a>.",
 
   "donation_comment_popup_title": "Leave a donation comment",
   "donation_comment_popup_explanation": "If you like, please tell us the reason for your donation. How are you involved with Wikipedia? Your story helps to illustrate Wikipedia's significance for millions of people who use the site every day.",
@@ -125,6 +131,7 @@
   "donation_confirmation_inline_summary": "You will donate: <strong>{interval} €{formattedAmount}</strong> via <strong>{paymentType}</strong>.",
   "donation_confirmation_address_usage_link": "more information",
   "donation_confirmation_address_usage_content": "We need your postal address in order to send you a donation receipt. Sending it by email is currently still not secure enough. In addition, we send donation requests every once in a while, when Wikipedia needs your help again. If you do not want to receive these donation requests, please let us know by sending an email to spenden@wikimedia.de. You will then receive your donation receipt to your home address.",
+  "donation_confirmation_address_usage_content_vuei18n_v3": "We need your postal address in order to send you a donation receipt. Sending it by email is currently still not secure enough. In addition, we send donation requests every once in a while, when Wikipedia needs your help again. If you do not want to receive these donation requests, please let us know by sending an email to spenden{'@'}wikimedia.de. You will then receive your donation receipt to your home address.",
 
   "donation_form_academic_title_label": "Title",
   "donation_form_academic_title_option_none": "No title",
@@ -250,6 +257,7 @@
   "donation_form_email_error": "Please enter a valid email address.",
   "donation_form_email_label": "Email",
   "donation_form_email_placeholder": "bloggs@example.com",
+  "donation_form_email_placeholder_vuei18n_v3": "bloggs{'@'}example.com",
   "donation_form_email_placeholder_warning": "Are you sure that your email is {value}?",
   "donation_form_email_suggestion": "Did you mean",
   "donation_form_finalize": "Donate now",
@@ -262,8 +270,10 @@
   "donation_form_lastname_placeholder_check": "Bloggs",
   "donation_form_lastname_placeholder_warning": "Are you sure that your surname is {value}?",
   "donation_form_newsletter_label": "Yes, I would like to be notified if Wikipedia needs my help in the future. I understand I can revoke my consent at any time by sending an email to spenden@wikimedia.de.",
+  "donation_form_newsletter_label_vuei18n_v3": "Yes, I would like to be notified if Wikipedia needs my help in the future. I understand I can revoke my consent at any time by sending an email to spenden{'@'}wikimedia.de.",
   "donation_form_newsletter_label_paragraph_1": "Yes, I would like to be notified if Wikipedia needs my help in the future.",
   "donation_form_newsletter_label_paragraph_2": "If you do not want to receive emails, please uncheck the box. You can also unsubscribe at any time in the future, for example, via the unsubscribe link at the bottom of each email or by sending an email to spenden@wikimedia.de. You can find further information in our <a href=\"https://spenden.wikimedia.de/page/Datenschutz\">privacy policy</a>.",
+  "donation_form_newsletter_label_paragraph_2_vuei18n_v3": "If you do not want to receive emails, please uncheck the box. You can also unsubscribe at any time in the future, for example, via the unsubscribe link at the bottom of each email or by sending an email to spenden{'@'}wikimedia.de. You can find further information in our <a href=\"https://spenden.wikimedia.de/page/Datenschutz\">privacy policy</a>.",
   "donation_form_payment_amount_error": "Unfortunately, due to applicable fees, you have to state a minimum amount of EUR 1. If you would like to donate less, please transfer the amount directly to the donation account stated below.",
   "donation_form_payment_amount_too_high": "The amount must not exceed €99999.",
   "donation_form_payment_amount_legend": "Please enter your desired amount.",
@@ -334,6 +344,7 @@
 
   "membership_cancellation_title": "Your membership application was cancelled.",
   "membership_cancellation_text": "Your membership application with the number {membership_id} was cancelled. If you have any questions or would like to inform us about any problems, please contact <a href=\"mailto:%mailto_link%\">members@wikimedia.de</a>.",
+  "membership_cancellation_text_vuei18n_v3": "Your membership application with the number {membership_id} was cancelled. If you have any questions or would like to inform us about any problems, please contact <a href=\"mailto:%mailto_link%\">members{'@'}wikimedia.de</a>.",
 
   "membership_confirmation_thanks_text": "Thank you for your sponsorship!",
   "membership_confirmation_data_text": "You are becoming a <strong>{membershipType}</strong> with Wikimedia Deutschland e. V.<br>and pay <strong>{membershipFeeFormatted} {paymentInterval}</strong> {membershipFeeYearlyFormatted} by <strong>{paymentType}</strong><br>from {address}",

--- a/i18n/en_GB/messages/messages.json
+++ b/i18n/en_GB/messages/messages.json
@@ -1,4 +1,7 @@
 {
+  "yes": "Yes",
+  "no": "No",
+
   "access_denied": "You are not authorised to view this page.",
   "access_denied_header": "Error",
   "access_denied_donation_confirmation": "You are not authorised to view this donation.",


### PR DESCRIPTION
App symbols in the newer version of Vuei18n are now reserved so the ones used in email addresses need to be input as a literal string.