### PR TITLE
Use plural in confirmation mails

### DIFF
--- a/i18n/de_DE/mail/donation_confirmation/greetings.twig
+++ b/i18n/de_DE/mail/donation_confirmation/greetings.twig
@@ -1,3 +1,3 @@
-Mit Ihrem Engagement helfen Sie Wikipedia zu finanzieren. Gemeinsam mit den ehrenamtlichen Autorinnen und Autoren sorgen wir für einen freien Zugang zu Wissen. Es freut mich, dass Sie dabei sind.
+Mit Ihrem Engagement helfen Sie Wikipedia zu finanzieren. Gemeinsam mit den ehrenamtlichen Autorinnen und Autoren sorgen wir für einen freien Zugang zu Wissen. Es freut uns, dass Sie dabei sind.
 
 Freundliche Grüße aus Berlin und Ihnen noch einen angenehmen {$ day_of_the_week $}.

--- a/i18n/de_DE/mail/donation_confirmation/payment_intro.twig
+++ b/i18n/de_DE/mail/donation_confirmation/payment_intro.twig
@@ -1,1 +1,1 @@
-ich danke Ihnen für Ihre soeben getätigte {$ donation_interval $}e Spende (Nr. {$ donation_id $}) von {$ formatted_amount $}.
+wir danken Ihnen für Ihre soeben getätigte {$ donation_interval $}e Spende (Nr. {$ donation_id $}) von {$ formatted_amount $}.

--- a/i18n/de_DE/mail/donation_confirmation/paymenttype_banktransfer.twig
+++ b/i18n/de_DE/mail/donation_confirmation/paymenttype_banktransfer.twig
@@ -1,4 +1,4 @@
-ich danke Ihnen für Ihre soeben getätigte {$ donation_interval $}e Spendenzusage (Nr. {$ donation_id $}). Sie haben es fast geschafft. Jetzt müssen Sie nur noch Ihre Spende über {$ formatted_amount $} auf folgendes Konto überweisen:
+wir danken Ihnen für Ihre soeben getätigte {$ donation_interval $}e Spendenzusage (Nr. {$ donation_id $}). Sie haben es fast geschafft. Jetzt müssen Sie nur noch Ihre Spende über {$ formatted_amount $} auf folgendes Konto überweisen:
 
 * Kontoinhaberin: Wikimedia
 * IBAN: DE09 3702 0500 0003 2873 00

--- a/i18n/de_DE/shared/title_head_of_organization.twig
+++ b/i18n/de_DE/shared/title_head_of_organization.twig
@@ -1,1 +1,1 @@
-Geschäftsführender Vorstand
+Geschäftsführende Vorstände

--- a/i18n/en_GB/mail/donation_confirmation/greetings.twig
+++ b/i18n/en_GB/mail/donation_confirmation/greetings.twig
@@ -1,3 +1,3 @@
-With your committed support, you are helping to fund Wikipedia. Together with the volunteers who write for Wikipedia, we facilitate free access to knowledge. And I am delighted that you are taking part.
+With your committed support, you are helping to fund Wikipedia. Together with the volunteers who write for Wikipedia, we facilitate free access to knowledge. And we are delighted that you are taking part.
 
 Best wishes from Berlin and have a pleasant {$ day_of_the_week $}.


### PR DESCRIPTION
- the email is signed by 2 directors now, that should be reflected in the text of the mails