### PR TITLE
Add text for a survey tile on donation confirmation page.

### DIFF
--- a/i18n/de_DE/messages/messages.json
+++ b/i18n/de_DE/messages/messages.json
@@ -454,5 +454,11 @@
   "C23_WMDE_Desktop_DE_05_contact_details_company": "Firma",
 
   "hall_of_fame_header_paragraph1": "Die Spenden und Mitgliedsbeiträge unserer Unterstützenden sichern Wikipedia und ihre Schwesterprojekte. Sie ermöglichen die Arbeit der Freiwilligen, die freie Verfügbarkeit von Wikipedia und die Unabhängigkeit der Organisation. Ihnen allen danken wir von Herzen!",
-  "hall_of_fame_header_paragraph2": "Mit der Hall of Fame würdigen wir auf Wunsch besonders großzügige Spenden und Beiträge. Vielen Dank für Ihr großes Engagement und dass Sie es für alle sichtbar machen!"
+  "hall_of_fame_header_paragraph2": "Mit der Hall of Fame würdigen wir auf Wunsch besonders großzügige Spenden und Beiträge. Vielen Dank für Ihr großes Engagement und dass Sie es für alle sichtbar machen!",
+
+  "donation_confirmation_survey_title": "Was hätte Sie fast davon abgehalten, zu spenden?",
+  "donation_confirmation_survey_content": "Ihre Antwort hilft uns, unseren Service und unsere Webseite zu verbessern.",
+  "donation_confirmation_survey_link_text": "Feedback geben",
+  "donation_confirmation_survey_link": "https://lime.wikimedia.de/index.php/643269?lang=de"
+
 }

--- a/i18n/en_GB/messages/messages.json
+++ b/i18n/en_GB/messages/messages.json
@@ -458,6 +458,11 @@
   "C23_WMDE_Desktop_DE_05_contact_details_company": "My Workplace",
 
   "hall_of_fame_header_paragraph1": "Your donations support Wikipedia, the free online encyclopedia, created, edited, and verified by volunteers around the world, as well as many other vital community projects. All of which is made possible thanks to donations from individuals like you. Thank you!",
-  "hall_of_fame_header_paragraph2": "The Hall of Fame celebrates those who gave at a very high level. Thank you again for your support and for making it visible to all."
+  "hall_of_fame_header_paragraph2": "The Hall of Fame celebrates those who gave at a very high level. Thank you again for your support and for making it visible to all.",
+
+  "donation_confirmation_survey_title": "What almost stopped you from donating?",
+  "donation_confirmation_survey_content": "Your response helps us to improve our service and our website.",
+  "donation_confirmation_survey_link_text": "Give feedback",
+  "donation_confirmation_survey_link": "https://lime.wikimedia.de/index.php/643269?lang=en"
 
 }


### PR DESCRIPTION
The link in the tile leads to either the German or the English version of the survey.

Ticket: https://phabricator.wikimedia.org/T349193