### PR TITLE
Correct the tense for donation via external payment provider

### DIFF
--- a/i18n/de_DE/messages/messages.json
+++ b/i18n/de_DE/messages/messages.json
@@ -131,7 +131,7 @@
   "donation_confirmation_topbox_donor_type_person": "als Privatperson",
   "donation_confirmation_topbox_email": "E-Mail-Adresse: {email}",
   "donation_confirmation_topbox_intro": "Herzlichen Dank für Ihre Spende!",
-  "donation_confirmation_topbox_summary": "Sie spenden:<br><strong>{interval}</strong><br><strong>{formattedAmount}</strong> per<br><strong>{paymentType}</strong> <br>{personType}<br>{address}<br>",
+  "donation_confirmation_topbox_summary": "Sie haben gespendet: <strong>{interval} </strong><strong>{formattedAmount}</strong> per <strong>{paymentType}</strong>.",
   "donation_confirmation_inline_summary": "Sie spenden: <strong>{interval} {formattedAmount}</strong> per <strong>{paymentType}</strong>.",
   "donation_confirmation_address_usage_link": "mehr Informationen",
   "donation_confirmation_address_usage_content": "Wir benötigen Ihre Postanschrift, um Ihnen Ihre Spendenquittung zusenden zu können. Ein Versenden per e-Mail ist derzeit noch nicht sicher genug. Darüber hinaus versenden wir ab und zu Spendenbitten, wenn Wikipedia wieder Ihre Hilfe benötigt. Wenn Sie diese nicht erhalten möchten, können Sie uns dies per E-Mail an spenden@wikimedia.de formlos mitteilen. Dann bekommen Sie nur Ihre Spendenquittung nach Hause geschickt.",

--- a/i18n/en_GB/messages/messages.json
+++ b/i18n/en_GB/messages/messages.json
@@ -131,7 +131,7 @@
   "donation_confirmation_topbox_donor_type_person": "as a private individual",
   "donation_confirmation_topbox_email": "Email address: {email}",
   "donation_confirmation_topbox_intro": "Thank you very much for your donation!",
-  "donation_confirmation_topbox_summary": "You donated:<br><strong>{interval}</strong><br><strong>{formattedAmount}</strong> via<br><strong>{paymentType}</strong>.",
+  "donation_confirmation_topbox_summary": "You donated: <strong>{interval} </strong><strong>{formattedAmount}</strong> via <strong>{paymentType}</strong>.",
   "donation_confirmation_inline_summary": "You will donate: <strong>{interval} €{formattedAmount}</strong> via <strong>{paymentType}</strong>.",
   "donation_confirmation_address_usage_link": "more information",
   "donation_confirmation_address_usage_content": "We need your postal address in order to send you a donation receipt. Sending it by email is currently still not secure enough. In addition, we send donation requests every once in a while, when Wikipedia needs your help again. If you do not want to receive these donation requests, please let us know by sending an email to spenden@wikimedia.de. You will then receive your donation receipt to your home address.",


### PR DESCRIPTION
Correst the tense for success message for donation via external payment provider This correction is needed only for German language message as the correct message for English language already exists

Ticket: https://phabricator.wikimedia.org/T344424