### PR TITLE
Cleanup -- Fix - Breaking single characters into a new line problem

### DIFF
--- a/i18n/de_DE/data/use_of_funds_content.json
+++ b/i18n/de_DE/data/use_of_funds_content.json
@@ -1,6 +1,5 @@
 {
 	"intro": {
-		"headline": "Wofür wird Ihre Spende verwendet?",
 		"dynamicHeadline": {
 			"published": "Wofür wird Ihre Spende verwendet?",
 			"provisional": "Wofür wird Ihre Spende verwendet<nobr>?*</nobr>"

--- a/i18n/en_GB/data/use_of_funds_content.json
+++ b/i18n/en_GB/data/use_of_funds_content.json
@@ -1,6 +1,5 @@
 {
 	"intro": {
-		"headline": "Where does my donation go?",
 		"dynamicHeadline": {
 			"published": "Where does my donation go?",
 			"provisional": "Where does my donation go<nobr>?*</nobr>"


### PR DESCRIPTION
- Remove the 'headline' key-pair which was kept for backward compatibility
- This is the previous fix pr: https://github.com/wmde/fundraising-frontend-content/pull/252

Ticket: https://phabricator.wikimedia.org/T352982