### PR TITLE
Update imprint.twig

### DIFF
--- a/i18n/de_DE/web/pages/imprint.twig
+++ b/i18n/de_DE/web/pages/imprint.twig
@@ -4,7 +4,7 @@
 </p>
 <p>
 	<strong>Diensteanbieter</strong><br />
-		Wikimedia Deutschland e. V.<br />
+		Wikimedia Deutschland - Gesellschaft zur Förderung Freien Wissens e. V.<br />
 		Tempelhofer Ufer 23-24<br />
 		10963 Berlin<br />
 	<br />
@@ -27,7 +27,7 @@
 	Spendenkonto: <br />
 	IBAN: DE09 3702 0500 0003 2873 00 <br />
 	BIC: BFSWDE33BER <br />
-	Bank für Sozialwirtschaft <br />
+	SozialBank <br />
 	<br />
 	Eingetragen im Vereinsregister des Amtsgerichts Charlottenburg, VR 23855 B.
 </p>


### PR DESCRIPTION
changed our name to Wikimedia Deutschland - Gesellschaft zur Förderung Freien Wissens e. V.