### PR TITLE
Add a translation for new donation form summary behaviour

### DIFF
--- a/i18n/de_DE/messages/messages.json
+++ b/i18n/de_DE/messages/messages.json
@@ -308,6 +308,7 @@
   "donation_form_payment_interval_title": "Wie häufig möchten Sie spenden?",
   "donation_form_SUB_payment_type_info": "Eine regelmäßige Zahlung per Sofortüberweisung ist nicht möglich.",
   "donation_form_payment_summary": "Sie spenden: {interval} {formattedAmount} per {paymentType}",
+  "donation_form_payment_summary_payment_type_missing": "Sie spenden: {interval} {formattedAmount}",
   "donation_form_payment_type_error": "Welche Zahlungsmethode möchten Sie verwenden?",
   "donation_form_payment_type_title": "Wie möchten Sie spenden?",
   "donation_form_salutation_error": "Bitte teilen Sie uns mit, wie Sie angesprochen werden möchten.",

--- a/i18n/en_GB/messages/messages.json
+++ b/i18n/en_GB/messages/messages.json
@@ -311,6 +311,7 @@
   "donation_form_payment_interval_title": "How often would you like to donate?",
   "donation_form_SUB_payment_type_info": "A recurring payment by Sofort Bank Transfer is not possible.",
   "donation_form_payment_summary": "You donate: {interval} {formattedAmount} via {paymentType}",
+  "donation_form_payment_summary_payment_type_missing": "You donate: {interval} {formattedAmount}",
   "donation_form_payment_type_error": "What is your preferred payment method?",
   "donation_form_payment_type_title": "How would you like to donate?",
   "donation_form_salutation_error": "Please provide your preferred form of address.",


### PR DESCRIPTION
- When there is no payment type passed to the donation form, the summary only shows the data that is already there
- When selecting a payment type, the summary reflects that
- To implement this we need a new translation key - 'donation_form_payment_summary'

Ticket: https://phabricator.wikimedia.org/T368527