### PR TITLE
Add provisional messages for C24_WMDE_Mobile_DE_10

### DIFF
--- a/i18n/de_DE/messages/messages.json
+++ b/i18n/de_DE/messages/messages.json
@@ -218,6 +218,9 @@
   "donation_form_provisional_address_choice_emailonly_notice_donation_receipt": "Sie verzichten auf eine Spendenquittung, erhalten aber eine Bestätigung per E-Mail.",
 
 
+  "donation_form_section_address_opt_out": "Möchten Sie Ihre Adresse angeben?",
+  "donation_form_section_address_opt_out_help_text": "Nur so können wir Ihnen eine Spendenquittung per Post zusenden. Außerdem erhalten Sie eine Bestätigung per E-Mail.",
+
 
   "donation_confirmation_summary_title": "Ihre Spendenquittung erhalten Sie an folgende Adresse:",
   "donation_confirmation_summary_title_no_receipt_wanted": "Folgende Adresse haben wir von Ihnen erhalten:",
@@ -423,6 +426,7 @@
   "error_summary_address_type": "Bitte wählen Sie einen Adresstyp aus",
   "error_summary_interval": "Bitte wählen sie ein Zahlungsintervall aus",
   "error_summary_iban": "Bitte geben Sie eine korrekte IBAN oder Kontonummer an",
+  "error_summary_address_type_opt_out": "Bitte wählen Sie eine Adressoption aus",
 
   "form_trust_message" : "Verschlüsselte Datenübertragung und sichere Bezahlung",
 

--- a/i18n/de_DE/messages/messages.json
+++ b/i18n/de_DE/messages/messages.json
@@ -219,7 +219,7 @@
 
 
   "donation_form_section_address_opt_out": "Möchten Sie Ihre Adresse angeben?",
-  "donation_form_section_address_opt_out_help_text": "Nur so können wir Ihnen eine Spendenquittung per Post zusenden. Außerdem erhalten Sie eine Bestätigung per E-Mail.",
+  "donation_form_section_address_opt_out_help_text": "Ohne Adresssangabe können wir Ihnen keine Spendenbescheinigung zustellen",
 
 
   "donation_confirmation_summary_title": "Ihre Spendenquittung erhalten Sie an folgende Adresse:",

--- a/i18n/en_GB/messages/messages.json
+++ b/i18n/en_GB/messages/messages.json
@@ -221,6 +221,9 @@
   "donation_form_provisional_address_choice_emailonly_notice_donation_receipt": "For this we only need name and e-mail address. However, you will not receive a donation receipt.",
 
 
+  "donation_form_section_address_opt_out": "Would you like to give us your address?",
+  "donation_form_section_address_opt_out_help_text": "You will receive a donation receipt by mail. You will also receive an e-mail confirmation of your donation.",
+
 
   "donation_confirmation_summary_title": "We will send your donation receipt to the following:",
   "donation_confirmation_summary_title_no_receipt_wanted": "We have received the following address from you:",
@@ -426,6 +429,7 @@
   "error_summary_address_type": "Please select an address type",
   "error_summary_interval": "Please select a payment interval",
   "error_summary_iban": "Please enter a correct IBAN",
+  "error_summary_address_type_opt_out": "Please choose an address option",
 
   "form_trust_message" : "Verschlüsselte Datenübertragung und sichere Bezahlung",
 

--- a/i18n/en_GB/messages/messages.json
+++ b/i18n/en_GB/messages/messages.json
@@ -222,7 +222,7 @@
 
 
   "donation_form_section_address_opt_out": "Would you like to give us your address?",
-  "donation_form_section_address_opt_out_help_text": "You will receive a donation receipt by mail. You will also receive an e-mail confirmation of your donation.",
+  "donation_form_section_address_opt_out_help_text": "Without an adress, we can't send you a donation receipt",
 
 
   "donation_confirmation_summary_title": "We will send your donation receipt to the following:",


### PR DESCRIPTION
These are the texts for the new "address-opt-out" form, first tested in
C24_WMDE_Mobile_DE_10. Delete the messages when the feature no longer
exists.

Ticket: https://phabricator.wikimedia.org/T380462
