### PR TITLE
Fix English text in German translation file

### DIFF
--- a/i18n/de_DE/data/use_of_funds_2024.json
+++ b/i18n/de_DE/data/use_of_funds_2024.json
@@ -66,21 +66,21 @@
 					"budget": 306,
 					"budgetString": "306 Mrd. $",
 					"link": "https://www.statista.com/statistics/266206/googles-annual-global-revenue/",
-					"linkText": "Source"
+					"linkText": "Quelle"
 				},
 				{
 					"name": "Amazon",
 					"budget": 575,
 					"budgetString": "575 Mrd. $",
 					"link": "https://www.statista.com/statistics/266282/annual-net-revenue-of-amazoncom/",
-					"linkText": "Source"
+					"linkText": "Quelle"
 				},
 				{
 					"name": "Facebook",
 					"budget": 135,
 					"budgetString": "135 Mrd. $",
 					"link": "https://www.statista.com/statistics/268604/annual-revenue-of-facebook/",
-					"linkText": "Source"
+					"linkText": "Quelle"
 				},
 				{
 					"name": "Wikipedia",


### PR DESCRIPTION
Not sure what the reason was for this being in English, but it used to be Quelle in 2023