### PR TITLE
Do not trigger deploy on pull requests

### DIFF
--- a/.woodpecker/deploy_content.yml
+++ b/.woodpecker/deploy_content.yml
@@ -21,7 +21,7 @@ steps:
   - name: deploy
     when:
       - branch: [ test, production ]
-        event: [ push, pull_request, cron, manual ]
+        event: [ push, cron, manual ]
     image: wikimediade/ansible-deploy
     pull: false # Until we publish the image on a registry
     environment:


### PR DESCRIPTION
When doing a pull request from a feature branch on GitHub, the `branch` variable is the *target* of the pull request not the name of the feature branch.
See https://woodpecker-ci.org/docs/usage/workflow-syntax#branch

This commit removes the `pull_request` condition, which means that only pushes to the `test` and `production` branches will trigger the deployment.

Ticket: https://phabricator.wikimedia.org/T396226