### PR TITLE
Nothing is displayed if user selects - No salutation

### DIFF
--- a/i18n/de_DE/data/salutations.json
+++ b/i18n/de_DE/data/salutations.json
@@ -24,7 +24,7 @@
 		},
 		{
 			"label": "Keine Angabe",
-			"value": "Divers",
+			"value": "",
 			"export_value": "divers",
 			"display": "",
 			"greetings" : {

--- a/i18n/en_GB/data/salutations.json
+++ b/i18n/en_GB/data/salutations.json
@@ -24,7 +24,7 @@
 		},
 		{
 			"label": "No Specification",
-			"value": "No Title",
+			"value": "",
 			"export_value": "divers",
 			"display": "",
 			"greetings" : {


### PR DESCRIPTION
- Requirement: If the salutation option "No specification"/"Keine Angabe" is selected, the field value ("No Title"/"Divers") should not be displayed in the summary box

Ticket:https://phabricator.wikimedia.org/T390841

----

The latest fix is on the test pool - https://testing04.wikimedia.customers.manitu.net/